### PR TITLE
compile under Java 8

### DIFF
--- a/cf-code-coverage/pom.xml
+++ b/cf-code-coverage/pom.xml
@@ -7,8 +7,8 @@
 		<cfusion.version>11</cfusion.version>
 		<cfusion.jar.location>/Volumes/Sources/git/cf-metrics/lib/cfusion.jar</cfusion.jar.location>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aspectj.version>1.7.3</aspectj.version>
-        <java.version>7</java.version>
+        <aspectj.version>1.8.7</aspectj.version>
+        <java.version>8</java.version>
 	</properties>
 	
 	<groupId>org.kacperus</groupId>
@@ -52,9 +52,9 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>aspectj-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>1.8</version>
                     <configuration>
-                        <complianceLevel>1.7</complianceLevel>
+                        <complianceLevel>1.8</complianceLevel>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
                         <Xlintfile>src/main/config/Xlint.properties</Xlintfile>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.7</version>
                 <configuration>
                     <weaveDependencies>
                         <weaveDependency>


### PR DESCRIPTION
I kept getting error `The type java.util.Map$Entry cannot be resolved. It is indirectly referenced from required .class files` when I tried to `maven clean install` the `cf-code-coverage` part of the project using Java 1.8.65 in aWindows x64 environment..
After some google'ing I increased the depending AspectJ version numbers. Now it compiles as I expect.
